### PR TITLE
Use VIN as ConfigEntry.unique_id

### DIFF
--- a/custom_components/teslafi/config_flow.py
+++ b/custom_components/teslafi/config_flow.py
@@ -26,7 +26,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _client: TeslaFiClient | None
 
-    VERSION = 2
+    VERSION = 3
 
     def __init__(self) -> None:
         self._client = None
@@ -78,5 +78,5 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return None
         return {
             "title": result.name,
-            "id": result.id,
+            "id": result.vin,
         }

--- a/custom_components/teslafi/model.py
+++ b/custom_components/teslafi/model.py
@@ -1,6 +1,7 @@
 """TeslaFi Object Models"""
 
 from collections import UserDict
+from typing_extensions import deprecated
 
 from .const import SHIFTER_STATES, VIN_YEARS
 
@@ -33,14 +34,16 @@ class TeslaFiVehicle(UserDict):
             super().update(filtered)
 
     @property
+    @deprecated("Use .vin instead")
     def id(self) -> str:
         """Vehicle id"""
-        return self.get("id", None)
+        return self.get("id", self.vin)
 
     @property
+    @deprecated("Use .vin instead")
     def vehicle_id(self) -> str:
         """Vehicle id"""
-        return self.get("vehicle_id", None)
+        return self.get("vehicle_id", self.vin)
 
     @property
     def odometer(self) -> float:


### PR DESCRIPTION
We were originally using TeslaFi's `.id` field, which used to contain a value. But at some point that field was removed, along with `.vehicle_id`, and the only unique field we can use now is `.vin`.

This also adds a config flow migration in order to set the unique_id for existing config entries.