### PR TITLE
Fix error response detection

### DIFF
--- a/custom_components/teslafi/client.py
+++ b/custom_components/teslafi/client.py
@@ -62,7 +62,12 @@ class TeslaFiClient:
             _LOGGER.warning("Error reading as json: %s", response.text, exc_info=True)
             raise SyntaxError("Failed parsing JSON") from exc
 
-        if data is dict and (err := data.get("error")):
-            raise RuntimeError(f"{err}: {data.get('error_description')}")
+        if isinstance(data, dict):
+            if err := data.get("error"):
+                raise RuntimeError(f"{err}: {data.get('error_description')}")
+            if data.get("response", {}).get("result", None) == "unauthorized":
+                raise PermissionError(
+                    f"TeslaFi response unauthorized for api key {self._api_key}: {data}"
+                )
 
         return data


### PR DESCRIPTION
The check for `is dict` we were trying to use previously was wrong, and would have needed to be `type(data) is dict`. But that is not the recommended way to check for a dictionary anyway, so this fixes it to use `isinstance()` instead.

This also adds a check for a different way that TeslaFi can report an error: specifically, if the API key is not recognized, the response is completely different compared to when it is recognized but the API has been disabled; or the particular feature of the API is not enabled (such as unlocking). We were already checking for the latter, but not the former, so the error in this case is confusing.