### PR TITLE
Handle missing current on L3 charger

### DIFF
--- a/custom_components/teslafi/sensor.py
+++ b/custom_components/teslafi/sensor.py
@@ -116,6 +116,7 @@ SENSORS = [
         device_class=SensorDeviceClass.CURRENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         available=lambda u, d, h: u and d.is_plugged_in,
+        value=lambda d, h: d.charger_current,
     ),
     TeslaFiSensorEntityDescription(
         key="charge_energy_added",
@@ -146,8 +147,7 @@ SENSORS = [
         device_class=SensorDeviceClass.APPARENT_POWER,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        value=lambda d, h: int(d.get("charger_voltage"))
-        * int(d.get("charger_actual_current")),
+        value=lambda d, h: d.charger_voltage * d.charger_current,
         available=lambda u, d, h: u and d.is_plugged_in,
     ),
     # endregion


### PR DESCRIPTION
When on a L3 charger, we get `charger_actual_current=0`, which breaks the `apparent_power` synthetic sensor value.

From what I can see, we do not get a usable value for actual L3 current, in Amps. But we do get usable values for `charger_voltage` and `charger_power`. So, similar to how we can calculate `apparent_power=V*A`, we can also work backwards to get an estimated `charger_current=P/V`.

This will effectively make `charger_power == apparent_power` while on a L3 charger, but that's probably okay, because the integer `charger_power` will be more statistically significant than what we see on L2 and below.

Fixes #10 