### PR TITLE
Poll for pending HVAC states [fixes #21]

### DIFF
--- a/custom_components/teslafi/client.py
+++ b/custom_components/teslafi/client.py
@@ -46,11 +46,12 @@ class TeslaFiClient:
         """
         :param command: The command to send. Can be empty string, `lastGood`, etc. See
         """
+        timeout = kwargs.get("wake", 0) + REQUEST_TIMEOUT
         response = await self._client.get(
             url="https://www.teslafi.com/feed.php",
             headers={"Authorization": "Bearer " + self._api_key},
             params={"command": command} | kwargs,
-            timeout=REQUEST_TIMEOUT,
+            timeout=timeout,
         )
         assert response.status_code < 400
 

--- a/custom_components/teslafi/const.py
+++ b/custom_components/teslafi/const.py
@@ -16,6 +16,7 @@ POLLING_INTERVAL_DRIVING = timedelta(minutes=1)
 POLLING_INTERVAL_SLEEPING = timedelta(minutes=10)
 
 DELAY_CLIMATE = timedelta(seconds=30)
+DELAY_CMD_WAKE = timedelta(seconds=10)
 DELAY_LOCKS = timedelta(seconds=15)
 DELAY_WAKEUP = timedelta(seconds=30)
 

--- a/custom_components/teslafi/coordinator.py
+++ b/custom_components/teslafi/coordinator.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .client import TeslaFiClient
 from .const import (
+    DELAY_CMD_WAKE,
     DOMAIN,
     LOGGER,
     POLLING_INTERVAL_DEFAULT,
@@ -44,6 +45,8 @@ class TeslaFiCoordinator(DataUpdateCoordinator[TeslaFiVehicle]):
 
     async def execute_command(self, cmd: str, **kwargs) -> dict:
         """Execute the remote command."""
+        if self.data.is_sleeping:
+            kwargs["wake"] = DELAY_CMD_WAKE.seconds
         LOGGER.debug(">> executing command %s; args=%s", cmd, kwargs)
         result = await self._client.command(cmd, **kwargs)
         LOGGER.debug("<< command %s response: %s", cmd, result)


### PR DESCRIPTION
When setting mode=AUTO while the car is sleeping, the target state might not be reached until more than 30 seconds later (the delay we use after sending an HVAC command). In that case, what happens is:

1. Set hvac_mode=AUTO -> send hvac command -> write state
2. After 30 seconds, poll TeslaFi
3. If the state has not been updated yet, this will write state=OFF
4. Some time later (3 min default), TeslaFi has the updated state and will report state=AUTO

The transition from 2->3->4 causes the climate entity to flip states unexpectedly.

For `lock` and `alarm_control_panel` platforms, we retain a pending or target state, and on the next refresh if the pending state has not been met yet, we schedule another refresh, until the target state is met. This adds the same technique for climate mode.

We only do this for mode, because it's the one that is most likely to be set from a sleeping state.

In addition, we'll also ask TeslaFi to add the `wake=` parameter which will cause the API to wake the car first and wait a few seconds for the car to wake up before sending the real command.

Long term it would be great to have a better (and more reusable) way of doing this. Ideally the HA service call should not return until the target state is fully verified, but given the polling nature of both the integration and TeslaFi itself, this could cause problems in HA.