### PR TITLE
Handle turn on/off, remove aux heat [closes #29, #30]

### DIFF
--- a/custom_components/teslafi/coordinator.py
+++ b/custom_components/teslafi/coordinator.py
@@ -14,6 +14,7 @@ from .const import (
     POLLING_INTERVAL_DRIVING,
     POLLING_INTERVAL_SLEEPING,
 )
+from .errors import VehicleNotReadyError
 from .model import TeslaFiVehicle
 
 
@@ -48,7 +49,10 @@ class TeslaFiCoordinator(DataUpdateCoordinator[TeslaFiVehicle]):
         if self.data.is_sleeping:
             kwargs["wake"] = DELAY_CMD_WAKE.seconds
         LOGGER.debug(">> executing command %s; args=%s", cmd, kwargs)
-        result = await self._client.command(cmd, **kwargs)
+        try:
+            result = await self._client.command(cmd, **kwargs)
+        except VehicleNotReadyError as e:
+            LOGGER.warning(f"Failed sending command to vehicle: {e}")
         LOGGER.debug("<< command %s response: %s", cmd, result)
         return result
 

--- a/custom_components/teslafi/errors.py
+++ b/custom_components/teslafi/errors.py
@@ -1,0 +1,2 @@
+class VehicleNotReadyError(Exception):
+    """The vehicle is sleeping"""


### PR DESCRIPTION
Adds explicit support for `turn_on` and `turn_off`, since we only support AUTO mode.

To account for the removal of `aux_heat`, which we've been using for defrost (aka max preconditioning), this also moves the defrost functionality to preset=Boost.

* If climate was off when boost preset is selected, automatically switches to auto (that's how the car works)
* If climate was auto and the preset is switched back to none, then only turn off defrost, but keep climate on auto
* If climate was auto and preset Boost is selected, when turning off climate, also turn off defrost

Resolves #29 and #30 

* https://developers.home-assistant.io/blog/2024/03/10/climate-aux-heater-deprecated/
* https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/