### PR TITLE
Add start/stop charge switch [part of #28]

### DIFF
--- a/custom_components/teslafi/switch.py
+++ b/custom_components/teslafi/switch.py
@@ -23,6 +23,17 @@ SWITCHES = [
         available=lambda u, v, h: u and _convert_to_bool(v.get("is_climate_on")),
         cmd=lambda c, v: c.execute_command("steering_wheel_heater", statement=v),
     ),
+    TeslaFiSwitchEntityDescription(
+        key="_set_charging",
+        name="Charging",
+        icon="mdi:ev-station",
+        entity_registry_enabled_default=False,
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        available=lambda u, v, h: u and v.is_plugged_in,
+        value=lambda d, h: d.is_charging,
+        cmd=lambda c, v: c.execute_command("charge_start" if v else "charge_stop"),
+    ),
 ]
 
 

--- a/custom_components/teslafi/switch.py
+++ b/custom_components/teslafi/switch.py
@@ -49,10 +49,12 @@ class TeslaFiSwitchEntity(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.entity_description.cmd(self.coordinator, True)
+        self._attr_is_on = True
         return self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.entity_description.cmd(self.coordinator, False)
+        self._attr_is_on = False
         return self.async_write_ha_state()
 
 


### PR DESCRIPTION
This switch can take the place of the `binary_sensor.charging` entity, where the switch can be toggled off/on in order to stop/start charging.

The command(s) must be enabled in TeslaFi for this to work, and the way the entity appears in Home Assistant might be less desirable for some - that is why the entity is disabled by default.

If you want to keep the binary_sensor, but also still have the ability to stop/start charging, you can set the switch entity to hidden, and use some other means to toggle the switch, like with a Button or automation calling switch.* services.

![Screenshot 2024-04-13 at 1 14 20 PM](https://github.com/jhansche/ha-teslafi/assets/99272/bac732d3-1823-42f8-b433-9b49a3fd70ef)
