### PR TITLE
Update to Home Assistant 2024.11 [Fixes #49]

### DIFF
--- a/custom_components/teslafi/alarm_control_panel.py
+++ b/custom_components/teslafi/alarm_control_panel.py
@@ -1,24 +1,19 @@
+"""TeslaFi Alarm Control Panel."""
+
 from dataclasses import dataclass
+
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityDescription,
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_ALARM_ARMING,
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_DISARMING,
-    STATE_ALARM_DISARMED,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .base import (
-    TeslaFiBaseEntityDescription,
-    TeslaFiEntity,
-)
-from .const import DELAY_WAKEUP, DELAY_LOCKS, DOMAIN, LOGGER
+from .base import TeslaFiBaseEntityDescription, TeslaFiEntity
+from .const import DELAY_LOCKS, DELAY_WAKEUP, DOMAIN, LOGGER
 from .coordinator import TeslaFiCoordinator
 from .util import _convert_to_bool
 
@@ -28,13 +23,15 @@ class TeslaFiSentryEntityDescription(
     AlarmControlPanelEntityDescription,
     TeslaFiBaseEntityDescription,
 ):
-    """Alarm panel to control Sentry Mode"""
+    """Alarm panel to control Sentry Mode."""
 
 
 class TeslaFiSentryEntity(
     TeslaFiEntity[TeslaFiSentryEntityDescription],
     AlarmControlPanelEntity,
 ):
+    """TeslaFi Sentry Mode Alarm Control Panel."""
+
     _attr_code_arm_required: bool = False
     _attr_supported_features: AlarmControlPanelEntityFeature = (
         AlarmControlPanelEntityFeature.ARM_AWAY
@@ -46,17 +43,20 @@ class TeslaFiSentryEntity(
         coordinator: TeslaFiCoordinator,
         entity_description: TeslaFiSentryEntityDescription,
     ) -> None:
+        """Initialize the TeslaFi alarm control panel entity."""
         super().__init__(coordinator, entity_description)
         self._attr_changed_by = None
         self._target_state = None
 
     @property
     def icon(self) -> str | None:
-        if self.state == STATE_ALARM_ARMED_AWAY:
+        """Return the icon for the entity."""
+        if self.state == AlarmControlPanelState.ARMED_AWAY:
             return "mdi:shield-car"
         return super().icon
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send the disarm command to the Tesla vehicle."""
         LOGGER.debug("Disarming")
         response = await self.coordinator.execute_command(
             "set_sentry_mode", sentryMode=False
@@ -67,8 +67,8 @@ class TeslaFiSentryEntity(
         # > https://developer.tesla.com/docs/fleet-api#2023-10-09-rest-api-vehicle-commands-endpoint-deprecation-warning:
 
         if response:
-            self._target_state = STATE_ALARM_DISARMED
-            self._attr_state = STATE_ALARM_DISARMING
+            self._target_state = AlarmControlPanelState.DISARMED
+            self._attr_alarm_state = AlarmControlPanelState.DISARMING
             self._attr_changed_by = "hass"
             self.async_write_ha_state()
 
@@ -79,6 +79,7 @@ class TeslaFiSentryEntity(
                 self.coordinator.schedule_refresh_in(DELAY_LOCKS)
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        """Send the arm command to the Tesla vehicle."""
         LOGGER.debug("Arming")
         response = await self.coordinator.execute_command(
             "set_sentry_mode", sentryMode=True
@@ -89,8 +90,8 @@ class TeslaFiSentryEntity(
         # > https://developer.tesla.com/docs/fleet-api#2023-10-09-rest-api-vehicle-commands-endpoint-deprecation-warning:
 
         if response:
-            self._target_state = STATE_ALARM_ARMED_AWAY
-            self._attr_state = STATE_ALARM_ARMING
+            self._target_state = AlarmControlPanelState.ARMED_AWAY
+            self._attr_alarm_state = AlarmControlPanelState.ARMING
             self._attr_changed_by = "hass"
             self.async_write_ha_state()
 
@@ -109,7 +110,7 @@ class TeslaFiSentryEntity(
         if waiting:
             if new_state == target:
                 # It succeeded
-                self._attr_state = new_state
+                self._attr_alarm_state = new_state
                 self._attr_changed_by = "hass"
                 self._target_state = None
                 LOGGER.info("Target state succeeded: %s", target)
@@ -119,10 +120,10 @@ class TeslaFiSentryEntity(
                 return self.coordinator.schedule_refresh_in(DELAY_WAKEUP)
         elif old_state is None or new_state is None:
             self._attr_changed_by = None
-            self._attr_state = new_state
+            self._attr_alarm_state = new_state
         elif old_state != new_state:
             self._attr_changed_by = "remote"
-            self._attr_state = new_state
+            self._attr_alarm_state = new_state
 
         return super()._handle_coordinator_update()
 
@@ -133,7 +134,9 @@ ALARMS = [
         name="Sentry Mode",
         entity_registry_enabled_default=False,
         convert=lambda v: (
-            STATE_ALARM_ARMED_AWAY if _convert_to_bool(v) else STATE_ALARM_DISARMED
+            AlarmControlPanelState.ARMED_AWAY
+            if _convert_to_bool(v)
+            else AlarmControlPanelState.DISARMED
         ),
     ),
 ]
@@ -144,7 +147,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up from config entry"""
+    """Set up from config entry."""
     coordinator: TeslaFiCoordinator
     coordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
     entities: list[TeslaFiSentryEntity] = []

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "TeslaFi",
   "render_readme": true,
   "country": "US",
-  "homeassistant": "2024.4.0"
+  "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
As of HA 2024.11, the alarm and lock platforms have deprecated their previous state constants and replaced them with enum constants. Using the old constants results in a deprecation warning added to the logs. The old constants will be removed after 2025.10.

