### PR TITLE
Use longer wake allowance

### DIFF
--- a/custom_components/teslafi/const.py
+++ b/custom_components/teslafi/const.py
@@ -16,7 +16,7 @@ POLLING_INTERVAL_DRIVING = timedelta(minutes=1)
 POLLING_INTERVAL_SLEEPING = timedelta(minutes=10)
 
 DELAY_CLIMATE = timedelta(seconds=30)
-DELAY_CMD_WAKE = timedelta(seconds=10)
+DELAY_CMD_WAKE = timedelta(seconds=30)
 DELAY_LOCKS = timedelta(seconds=15)
 DELAY_WAKEUP = timedelta(seconds=30)
 


### PR DESCRIPTION
The TeslaFi API supports adding a `wake=N` argument that instructs TeslaFi to wait for up to `N` seconds for the car to wake up before sending the requested command. In my testing, wake=10 was sufficient to allow the car to wake up, but that testing was performed at home on wifi.

#39 and #47 report that 10 seconds may not be enough time to wake the car fully, but 30 seconds appears to be more reliable.

If the car is already awake when a command is being sent, then the argument will have no effect. So this should be a safe change.