### PR TITLE
Fix failing PyTest CI Check

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,8 +1,3 @@
 -r requirements.txt
 
-coverage==7.5.0
-pytest==8.2.0
-pytest-cov==5.0.0
-pytest-aiohttp==1.0.5
-pytest-asyncio==0.23.6
-pytest-homeassistant-custom-component==0.13.132
+pytest-homeassistant-custom-component==0.13.225


### PR DESCRIPTION
  - Removed redundant deps in `requirments.test.txt`
  - Updated `pytest-homeassistant-custom-component` to latest version

Resolves #70