### PR TITLE
Add command/wake count to polling process

### DIFF
--- a/custom_components/teslafi/client.py
+++ b/custom_components/teslafi/client.py
@@ -35,6 +35,13 @@ class TeslaFiClient:
         Return last data point with charge data
         """
         return TeslaFiVehicle(await self._request("lastGood"))
+    
+    async def request_counts(self) -> dict:
+        """
+        Return the TeslaFi API command/wakes counts
+        """
+    
+        return await self._request("command_count")
 
     async def current_data(self) -> TeslaFiVehicle:
         """

--- a/custom_components/teslafi/client.py
+++ b/custom_components/teslafi/client.py
@@ -35,13 +35,6 @@ class TeslaFiClient:
         Return last data point with charge data
         """
         return TeslaFiVehicle(await self._request("lastGood"))
-    
-    async def request_counts(self) -> dict:
-        """
-        Return the TeslaFi API command/wakes counts
-        """
-    
-        return await self._request("command_count")
 
     async def current_data(self) -> TeslaFiVehicle:
         """

--- a/custom_components/teslafi/coordinator.py
+++ b/custom_components/teslafi/coordinator.py
@@ -123,7 +123,13 @@ class TeslaFiCoordinator(DataUpdateCoordinator[TeslaFiVehicle]):
             )
         else:
             self._override_next_refresh = None
-
+            
+        # Refresh TeslaFi command counts
+        command_counts = await self._client.request_counts()
+        LOGGER.debug("TeslaFi command counts: %s", command_counts)
+        if command_counts is not None and "commands" in command_counts:
+            self._vehicle.update_non_empty(command_counts)
+        
         return self._vehicle
 
     def _infer_charge_session(

--- a/custom_components/teslafi/coordinator.py
+++ b/custom_components/teslafi/coordinator.py
@@ -104,6 +104,9 @@ class TeslaFiCoordinator(DataUpdateCoordinator[TeslaFiVehicle]):
             assert last_good.vin
 
         self._vehicle.update_non_empty(current)
+        # Refresh TeslaFi command counts
+        if (counts := current.get("tesla_request_counter", {})):
+            self._vehicle.update_non_empty(counts)
 
         LOGGER.debug("Remote data last updated %s", self._vehicle.last_remote_update)
 
@@ -123,12 +126,6 @@ class TeslaFiCoordinator(DataUpdateCoordinator[TeslaFiVehicle]):
             )
         else:
             self._override_next_refresh = None
-            
-        # Refresh TeslaFi command counts
-        command_counts = await self._client.request_counts()
-        LOGGER.debug("TeslaFi command counts: %s", command_counts)
-        if command_counts is not None and "commands" in command_counts:
-            self._vehicle.update_non_empty(command_counts)
         
         return self._vehicle
 

--- a/custom_components/teslafi/coordinator.py
+++ b/custom_components/teslafi/coordinator.py
@@ -126,7 +126,7 @@ class TeslaFiCoordinator(DataUpdateCoordinator[TeslaFiVehicle]):
             )
         else:
             self._override_next_refresh = None
-        
+
         return self._vehicle
 
     def _infer_charge_session(


### PR DESCRIPTION
These are just simple TeslaFi API calls similar to the vehicle data feed so they won't count against the wake/command usage. However this does now allow proper values on init, restarts, and if any commands are executed outside of HA.

Resolves #75